### PR TITLE
Convert Main class to extend from Game

### DIFF
--- a/Core/src/main/java/dk/sdu/mmmi/main/Main.java
+++ b/Core/src/main/java/dk/sdu/mmmi/main/Main.java
@@ -1,98 +1,27 @@
 package dk.sdu.mmmi.main;
 
-import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.graphics.OrthographicCamera;
-import com.badlogic.gdx.graphics.g2d.Sprite;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.utils.ScreenUtils;
-import dk.sdu.mmmi.common.data.entity.Entity;
-import dk.sdu.mmmi.main.CustomStages.CustomStage;
 import dk.sdu.mmmi.common.data.gameproperties.GameData;
-import dk.sdu.mmmi.common.data.world.World;
-import dk.sdu.mmmi.main.CustomStages.ICustomStage;
-import dk.sdu.mmmi.common.services.IEntityProcessingService;
-import dk.sdu.mmmi.common.services.IGamePluginService;
-import dk.sdu.mmmi.common.services.entityproperties.IActor;
-import dk.sdu.mmmi.common.services.map.IMapGenerator;
+import dk.sdu.mmmi.main.screens.PlayScreen;
 
-import java.util.*;
 
-import static java.util.stream.Collectors.toList;
-
-public class Main extends ApplicationAdapter {
+public class Main extends Game {
     private GameData gameData;
-    private World world;
-    private OrthographicCamera camera;
-    private SpriteBatch batch;
-    private HashMap<Entity, Sprite> entitySprites = new HashMap<>();
-    private ShapeRenderer shapeRenderer;
-    private Collection<ICustomStage> stages;
-    private CustomStage gameStage;
 
     @Override
     public void create() {
-        // Setup of game
-        gameData = GameData.getInstance();
-        world = World.getInstance();
-        camera = new OrthographicCamera();
-        float width = 25f;
-        float height = 25f * (Gdx.graphics.getHeight() / (float) Gdx.graphics.getWidth());
-        camera.setToOrtho(false, width, height);
-        shapeRenderer = new ShapeRenderer();
-        stages = new ArrayList<>();
-        gameStage = new CustomStage(2.5f * gameData.getScaler(), 2.5f * gameData.getScaler(),
-                11 * gameData.getScaler(), 11 * gameData.getScaler());
-        stages.add(gameStage);
-        batch = new SpriteBatch();
-        entitySprites = new HashMap<>();
-        createWorld();
-
-        // Initial start of plugins
-        for (IGamePluginService plugin : getPluginServices()) {
-            plugin.start(world, gameData);
-        }
+        this.gameData = GameData.getInstance();
+        setScreen(new PlayScreen(this));
     }
 
     @Override
     public void render() {
-        // Update game
-        ScreenUtils.clear(1, 1, 1, 1);
+        // update keys is relevant for all screens
+        this.updateKeys();
 
-        gameData.setDeltaTime(Gdx.graphics.getDeltaTime());
-        batch.setProjectionMatrix(camera.combined);
-        updateKeys();
-
-        // Disposes & delete entities that doesn't exist anymore
-        // Note: We have to add weapons which are going to be removed from the world, as we can't remove elements from
-        // world while we are iterating over it. Otherwise, we will get a ConcurrentModificationException as we are
-        // modifying a collection which we are iterating over.
-        if (entitySprites.keySet().size() != world.getEntities().size()) {
-            List<Entity> entitiesToBeRemoved = new ArrayList<>();
-            for (Entity entity : entitySprites.keySet()) {
-                if (!world.getEntities().contains(entity)) {
-                    entitiesToBeRemoved.add(entity);
-                }
-            }
-
-            if (!entitiesToBeRemoved.isEmpty()) {
-                for (Entity entity : entitiesToBeRemoved) {
-                    entitySprites.get(entity).getTexture().dispose();
-                    entitySprites.remove(entity);
-                }
-            }
-        }
-
-        for (IEntityProcessingService entityProcessingService : getEntityProcessingServices()) {
-            entityProcessingService.process(world, gameData);
-        }
-
-        gameStage.setEntitySprites(entitySprites);
-        gameStage.setEntities(world.getEntities());
-
-        stages.forEach(stage -> stage.drawStage(batch));
+        super.render();
     }
 
     /**
@@ -100,101 +29,42 @@ public class Main extends ApplicationAdapter {
      */
     private void updateKeys() {
         if (Gdx.input.isKeyPressed(Input.Keys.A) || Gdx.input.isKeyPressed(Input.Keys.LEFT)) {
-            gameData.getKeys().setKey(gameData.getKeys().getLeft(), true);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getLeft(), true);
         }
         if (Gdx.input.isKeyPressed(Input.Keys.D) || Gdx.input.isKeyPressed(Input.Keys.RIGHT)) {
-            gameData.getKeys().setKey(gameData.getKeys().getRight(), true);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getRight(), true);
         }
         if (Gdx.input.isKeyPressed(Input.Keys.W) || Gdx.input.isKeyPressed(Input.Keys.UP)) {
-            gameData.getKeys().setKey(gameData.getKeys().getUp(), true);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getUp(), true);
         }
         if (Gdx.input.isKeyPressed(Input.Keys.S) || Gdx.input.isKeyPressed(Input.Keys.DOWN)) {
-            gameData.getKeys().setKey(gameData.getKeys().getDown(), true);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getDown(), true);
         }
         if (Gdx.input.isKeyPressed(Input.Keys.SPACE)) {
-            gameData.getKeys().setKey(gameData.getKeys().getSpace(), true);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getSpace(), true);
         }
 
 
         if (!Gdx.input.isKeyPressed(Input.Keys.A) && !Gdx.input.isKeyPressed(Input.Keys.LEFT)) {
-            gameData.getKeys().setKey(gameData.getKeys().getLeft(), false);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getLeft(), false);
         }
         if (!Gdx.input.isKeyPressed(Input.Keys.D) && !Gdx.input.isKeyPressed(Input.Keys.RIGHT)) {
-            gameData.getKeys().setKey(gameData.getKeys().getRight(), false);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getRight(), false);
         }
         if (!Gdx.input.isKeyPressed(Input.Keys.W) && !Gdx.input.isKeyPressed(Input.Keys.UP)) {
-            gameData.getKeys().setKey(gameData.getKeys().getUp(), false);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getUp(), false);
         }
         if (!Gdx.input.isKeyPressed(Input.Keys.S) && !Gdx.input.isKeyPressed(Input.Keys.DOWN)) {
-            gameData.getKeys().setKey(gameData.getKeys().getDown(), false);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getDown(), false);
         }
         if (!Gdx.input.isKeyPressed(Input.Keys.SPACE)) {
-            gameData.getKeys().setKey(gameData.getKeys().getSpace(), false);
+            this.gameData.getKeys().setKey(this.gameData.getKeys().getSpace(), false);
         }
     }
 
     @Override
     public void dispose() {
-        batch.dispose();
-        for (Sprite sprite : entitySprites.values()) {
-            sprite.getTexture().dispose();
-        }
-    }
-
-    /**
-     * Get all plugins.
-     *
-     * @return a collection of all instances of IGamePluginService
-     */
-    private Collection<? extends IGamePluginService> getPluginServices() {
-        return ServiceLoader.load(IGamePluginService.class).stream().map(ServiceLoader.Provider::get).collect(toList());
-    }
-
-    /**
-     * Get all entity processing services.
-     *
-     * @return a collection of all instances of IEntityProcessingService
-     */
-    private Collection<? extends IEntityProcessingService> getEntityProcessingServices() {
-        return ServiceLoader.load(IEntityProcessingService.class).stream().map(ServiceLoader.Provider::get).collect(toList());
-    }
-
-
-    /**
-     * Checks if there is only one or less actor alive in the world.
-     * Useful for checking if the game is over.
-     *
-     * @return true if there is only one or less Entity in world, or if there is only one or less IActor in world.
-     */
-    private boolean isOneOrLessActorAlive() {
-        ArrayList<Entity> entities = world.getEntities();
-
-        if(entities.size() <= 1) {
-            return true;
-        }
-
-        boolean actorFound = false;
-
-        for(Entity entity : entities) {
-            if(entity instanceof IActor && !actorFound) {
-                actorFound = true;
-            } else if(entity instanceof IActor) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private void createWorld() {
-        this.world = World.getInstance();
-        ServiceLoader.Provider mapGenProvider = ServiceLoader.load(IMapGenerator.class).stream().findFirst().
-                orElse(null);
-        if (mapGenProvider != null) {
-            IMapGenerator mapGen = (IMapGenerator) mapGenProvider.get();
-            mapGen.generateMap(world);
-        } else {
-            world.generateDefaultMap();
-        }
+        screen.dispose(); // Note: The screen's dispose methods are not otherwise called automatically.
+        super.dispose(); // Don't know if this is necessary
     }
 }

--- a/Core/src/main/java/dk/sdu/mmmi/main/screens/PlayScreen.java
+++ b/Core/src/main/java/dk/sdu/mmmi/main/screens/PlayScreen.java
@@ -1,0 +1,221 @@
+package dk.sdu.mmmi.main.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.ScreenUtils;
+import dk.sdu.mmmi.common.data.entity.Entity;
+import dk.sdu.mmmi.common.data.gameproperties.GameData;
+import dk.sdu.mmmi.common.data.world.World;
+import dk.sdu.mmmi.common.services.IEntityProcessingService;
+import dk.sdu.mmmi.common.services.IGamePluginService;
+import dk.sdu.mmmi.common.services.entityproperties.IActor;
+import dk.sdu.mmmi.common.services.map.IMapGenerator;
+import dk.sdu.mmmi.main.CustomStages.CustomStage;
+import dk.sdu.mmmi.main.CustomStages.ICustomStage;
+import dk.sdu.mmmi.main.Main;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+public class PlayScreen implements Screen {
+    private final Main game; // To be used if the PlayScreen needs to call setScreen() to change to EndScreen, for instance.
+
+    // Imported from Main.java
+    private GameData gameData;
+    private World world;
+    private OrthographicCamera camera;
+    private SpriteBatch batch;
+    private HashMap<Entity, Sprite> entitySprites = new HashMap<>();
+    private ShapeRenderer shapeRenderer;
+    private Collection<ICustomStage> stages;
+    private CustomStage gameStage;
+
+    /**
+     * Constructor for PlayScreen - used roughly the same as the create() method, from the Main class.
+     *
+     * @param game the Main game instance - supplied so PlayScreen can call the SetScreen method on Main.
+     */
+    public PlayScreen(Main game) {
+        this.game = game;
+
+        // Setup of game - copied from Main.java
+        gameData = GameData.getInstance();
+        world = World.getInstance();
+        camera = new OrthographicCamera();
+        float width = 25f;
+        float height = 25f * (Gdx.graphics.getHeight() / (float) Gdx.graphics.getWidth());
+        camera.setToOrtho(false, width, height);
+        shapeRenderer = new ShapeRenderer();
+        stages = new ArrayList<>();
+        gameStage = new CustomStage(2.5f * gameData.getScaler(), 2.5f * gameData.getScaler(),
+                11 * gameData.getScaler(), 11 * gameData.getScaler());
+        stages.add(gameStage);
+        batch = new SpriteBatch();
+        entitySprites = new HashMap<>();
+        createWorld();
+
+        // Initial start of plugins
+        for (IGamePluginService plugin : getPluginServices()) {
+            plugin.start(world, gameData);
+        }
+    }
+
+    /**
+     * Show method from Screen interface - not used in this context.
+     */
+    @Override
+    public void show() {
+
+    }
+
+    /**
+     * Render method from Screen interface - used to render the game.
+     *
+     * @param v float value of the time since the last render - automatically supplied by the Main class.
+     */
+    @Override
+    public void render(float v) {
+        // Update game
+        ScreenUtils.clear(1, 1, 1, 1);
+
+        gameData.setDeltaTime(v);
+        batch.setProjectionMatrix(camera.combined);
+
+        // Disposes & delete entities that doesn't exist anymore
+        // Note: We have to add weapons which are going to be removed from the world, as we can't remove elements from
+        // world while we are iterating over it. Otherwise, we will get a ConcurrentModificationException as we are
+        // modifying a collection which we are iterating over.
+        if (entitySprites.keySet().size() != world.getEntities().size()) {
+            List<Entity> entitiesToBeRemoved = new ArrayList<>();
+            for (Entity entity : entitySprites.keySet()) {
+                if (!world.getEntities().contains(entity)) {
+                    entitiesToBeRemoved.add(entity);
+                }
+            }
+
+            if (!entitiesToBeRemoved.isEmpty()) {
+                for (Entity entity : entitiesToBeRemoved) {
+                    entitySprites.get(entity).getTexture().dispose();
+                    entitySprites.remove(entity);
+                }
+            }
+        }
+
+        for (IEntityProcessingService entityProcessingService : getEntityProcessingServices()) {
+            entityProcessingService.process(world, gameData);
+        }
+
+        gameStage.setEntitySprites(entitySprites);
+        gameStage.setEntities(world.getEntities());
+
+        stages.forEach(stage -> stage.drawStage(batch));
+    }
+
+    /**
+     * Resize method from Screen interface - not used in this context.
+     *
+     * @param i  int value of the new width of the screen.
+     * @param i1 int value of the new height of the screen.
+     */
+    @Override
+    public void resize(int i, int i1) {
+
+    }
+
+    /**
+     * Pause method from Screen interface - not used in this context.
+     */
+    @Override
+    public void pause() {
+
+    }
+
+    /**
+     * Resume method from Screen interface - not used in this context.
+     */
+    @Override
+    public void resume() {
+
+    }
+
+    /**
+     * Hide method from Screen interface - not used in this context.
+     */
+    @Override
+    public void hide() {
+
+    }
+
+    /**
+     * Dispose method from Screen interface - used to dispose of the game and it's objects, when it is closed.
+     */
+    @Override
+    public void dispose() {
+        batch.dispose();
+        for (Sprite sprite : entitySprites.values()) {
+            sprite.getTexture().dispose();
+        }
+    }
+
+    /**
+     * Get all plugins.
+     *
+     * @return a collection of all instances of IGamePluginService
+     */
+    private Collection<? extends IGamePluginService> getPluginServices() {
+        return ServiceLoader.load(IGamePluginService.class).stream().map(ServiceLoader.Provider::get).collect(toList());
+    }
+
+    /**
+     * Get all entity processing services.
+     *
+     * @return a collection of all instances of IEntityProcessingService
+     */
+    private Collection<? extends IEntityProcessingService> getEntityProcessingServices() {
+        return ServiceLoader.load(IEntityProcessingService.class).stream().map(ServiceLoader.Provider::get).collect(toList());
+    }
+
+
+    /**
+     * Checks if there is only one or less actor alive in the world.
+     * Useful for checking if the game is over.
+     *
+     * @return true if there is only one or less Entity in world, or if there is only one or less IActor in world.
+     */
+    private boolean isOneOrLessActorAlive() {
+        ArrayList<Entity> entities = world.getEntities();
+
+        if (entities.size() <= 1) {
+            return true;
+        }
+
+        boolean actorFound = false;
+
+        for (Entity entity : entities) {
+            if (entity instanceof IActor && !actorFound) {
+                actorFound = true;
+            } else if (entity instanceof IActor) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void createWorld() {
+        this.world = World.getInstance();
+        ServiceLoader.Provider mapGenProvider = ServiceLoader.load(IMapGenerator.class).stream().findFirst().
+                orElse(null);
+        if (mapGenProvider != null) {
+            IMapGenerator mapGen = (IMapGenerator) mapGenProvider.get();
+            mapGen.generateMap(world);
+        } else {
+            world.generateDefaultMap();
+        }
+    }
+}


### PR DESCRIPTION
## **This pull request includes:**
A refactoring of the Main class, to extend [Game](https://javadoc.io/static/com.badlogicgames.gdx/gdx/1.12.1/com/badlogic/gdx/Game.html) rather than [ApplicationAdapter](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/ApplicationAdapter.html). Both of those extend [ApplicationListener](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/ApplicationListener.html) anyways, with only slight differences in implementation.

One of Game's primary advantages: [Screens](https://javadoc.io/static/com.badlogicgames.gdx/gdx/1.12.1/com/badlogic/gdx/Screen.html)!

Created PlayScreen, and moved most of the game logic from Main to PlayScreen.

Will continue work on this branch - created the pull request early, in case others wanted to use the amazing Screens before I was done with the EndScreen.

---

By signing below, I acknowledge that any modifications I've made meet the following requirements:
- All new files have JavaDoc comments.
- I've run linting on my changes (Windows: CTRL + ALT + L).
- All tests pass.
- The components I've updated can be removed and the project will still work.

Signature: Thias
