### PR TITLE
Add "uses" line to TextureAnimator module-info

### DIFF
--- a/TextureAnimator/src/main/java/module-info.java
+++ b/TextureAnimator/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 import dk.sdu.mmmi.common.services.IGamePluginService;
+import dk.sdu.mmmi.common.services.textureanimator.IAnimatable;
 import dk.sdu.mmmi.common.services.textureanimator.ITextureAnimatorController;
 import dk.sdu.mmmi.textureAnimator.TextureAnimatorControlSystem;
 import dk.sdu.mmmi.textureAnimator.TextureAnimatorPlugin;
@@ -7,4 +8,5 @@ module TextureAnimator {
     requires Common;
     provides IGamePluginService with TextureAnimatorPlugin;
     provides ITextureAnimatorController with TextureAnimatorControlSystem;
+    uses IAnimatable;
 }


### PR DESCRIPTION
## **This pull request includes:**
A fix for the Stop method of TextureAnimator's plugin: The module-info now indicates the usage of the common IAnimatable interface.

---

By signing below, I acknowledge that any modifications I've made meet the following requirements:
- All new files have JavaDoc comments.
- I've run linting on my changes (Windows: CTRL + ALT + L).
- All tests pass.
- The components I've updated can be removed and the project will still work.

Signature: Thias
