### PR TITLE
Fixed an issue regarding enemy

### DIFF
--- a/Ai/src/main/java/dk/sdu/mmmi/ai/PathFinding.java
+++ b/Ai/src/main/java/dk/sdu/mmmi/ai/PathFinding.java
@@ -29,7 +29,7 @@ public class PathFinding implements IPathFinding {
 
     @Override
     public ArrayList<Node> pathFind(Node start, ArrayList<Node> listOfGoalNode, Map map) {
-        if(map == null){
+        if (map == null) {
             ArrayList<Node> emptyList = new ArrayList<>();
             return emptyList;
         }

--- a/Ai/src/main/java/dk/sdu/mmmi/ai/PathFinding.java
+++ b/Ai/src/main/java/dk/sdu/mmmi/ai/PathFinding.java
@@ -29,6 +29,10 @@ public class PathFinding implements IPathFinding {
 
     @Override
     public ArrayList<Node> pathFind(Node start, ArrayList<Node> listOfGoalNode, Map map) {
+        if(map == null){
+            ArrayList<Node> emptyList = new ArrayList<>();
+            return emptyList;
+        }
         maxCol = map.getWidth();
         maxRow = map.getHeight();
         nodeMap = new Node[maxCol][maxRow];
@@ -69,13 +73,10 @@ public class PathFinding implements IPathFinding {
                 nodeMap[col][row] = new Node(col, row);
 
                 col++;
-
                 if (col == maxCol) {
                     col = 0;
                     row++;
                 }
-
-
             }
 
             for (Entity entity : world.getEntities()) {

--- a/Enemy/src/main/java/dk/sdu/mmmi/enemy/EnemyPlugin.java
+++ b/Enemy/src/main/java/dk/sdu/mmmi/enemy/EnemyPlugin.java
@@ -63,8 +63,8 @@ public class EnemyPlugin implements IGamePluginService {
 
         this.gameData = gameDataParam;
         Entity enemy = createEnemy();
-        enemy.setY((world.getMap().getHeight() - 1) * gameData.getScaler());
-        enemy.setX((world.getMap().getWidth() - 1) * gameData.getScaler());
+        enemy.setY((world.getMap().getWidth() - 1) * gameData.getScaler());
+        enemy.setX((world.getMap().getHeight() - 1) * gameData.getScaler());
         world.addEntity(enemy);
 
 

--- a/Enemy/src/main/java/dk/sdu/mmmi/enemy/EnemyPlugin.java
+++ b/Enemy/src/main/java/dk/sdu/mmmi/enemy/EnemyPlugin.java
@@ -63,8 +63,8 @@ public class EnemyPlugin implements IGamePluginService {
 
         this.gameData = gameDataParam;
         Entity enemy = createEnemy();
-        enemy.setY(16);
-        enemy.setX(14);
+        enemy.setY((world.getMap().getHeight() - 1) * gameData.getScaler());
+        enemy.setX((world.getMap().getWidth() - 1) * gameData.getScaler());
         world.addEntity(enemy);
 
 


### PR DESCRIPTION
The game would crash when basic map was removed

## **This pull request includes:**
The enemy's spawn position  was hardcoded and when basic map is removed, the node parsed to pathfinding containing the enemy's position. Where the position were higher then the maps width and height, causing an out of bounds exception.
Changed enemy's spawn position to be based on the map rather then a hardcoded


---

By signing below, I acknowledge that any modifications I've made meet the following requirements:
- All new files have JavaDoc comments.
- I've run linting on my changes (Windows: CTRL + ALT + L).
- All tests pass.
- The components I've updated can be removed and the project will still work.

Signature: *Emil Kræmmer Jørgensen
